### PR TITLE
Add support to provide additional fields to the JSON object sent to redis

### DIFF
--- a/src/main/java/com/cwbase/logback/AdditionalField.java
+++ b/src/main/java/com/cwbase/logback/AdditionalField.java
@@ -1,0 +1,22 @@
+package com.cwbase.logback;
+
+public class AdditionalField {
+  private String key;
+  private String value;
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getKey() {
+    return this.key;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return this.value;
+  }
+}

--- a/src/main/java/com/cwbase/logback/JSONEventLayout.java
+++ b/src/main/java/com/cwbase/logback/JSONEventLayout.java
@@ -41,6 +41,7 @@ public class JSONEventLayout extends LayoutBase<ILoggingEvent> {
 	String sourceHost;
 	String sourcePath;
 	List<String> tags;
+	StringBuilder additionalFields;
 	String type;
 
 	@Override
@@ -181,6 +182,12 @@ public class JSONEventLayout extends LayoutBase<ILoggingEvent> {
 				buf.append("}");
 			}
 		}
+
+		if(additionalFields != null) {
+			buf.append(COMMA);
+			buf.append(additionalFields);
+		}
+
 		buf.append("}");
 
 		return buf.toString();
@@ -350,6 +357,15 @@ public class JSONEventLayout extends LayoutBase<ILoggingEvent> {
 	 */
 	public void setCallerStackIdx(int callerStackIdx) {
 		this.callerStackIdx = callerStackIdx;
+	}
+
+	public void addAdditionalField(AdditionalField p) {
+		if(additionalFields == null) {
+			additionalFields = new StringBuilder(DEFAULT_SIZE);
+		} else {
+			additionalFields.append(COMMA);
+		}
+		appendKeyValue(additionalFields, p.getKey(), p.getValue(), null);
 	}
 
 }

--- a/src/main/java/com/cwbase/logback/RedisAppender.java
+++ b/src/main/java/com/cwbase/logback/RedisAppender.java
@@ -178,6 +178,10 @@ public class RedisAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 		return layout.getCallerStackIdx();
 	}
 
+	public void addAdditionalField(AdditionalField p) {
+		layout.addAdditionalField(p);
+	}
+
 	@Override
 	public void start() {
 		super.start();

--- a/src/test/java/com/cwbase/logback/RedisAppenderTest.java
+++ b/src/test/java/com/cwbase/logback/RedisAppenderTest.java
@@ -46,6 +46,8 @@ public class RedisAppenderTest {
 
 		assertEquals("test-application", node.get("source").asText());
 		assertEquals("Test Log #1", node.get("message").asText());
+		assertEquals("MyValue", node.get("MyKey").asText());
+		assertEquals("MyOtherValue", node.get("MySecondKey").asText());
 	}
 
 	@Test

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -8,6 +8,14 @@
     <mdc>true</mdc>
     <location>true</location>
     <callerStackIndex>0</callerStackIndex>
+    <additionalField>
+      <key>MyKey</key>
+      <value>MyValue</value>
+    </additionalField>
+    <additionalField>
+      <key>MySecondKey</key>
+      <value>MyOtherValue</value>
+    </additionalField>
   </appender>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
This PR allows you to define additional fields that will be included in the message sent to redis. If, for example, a company policy requires additional fields you can add them via the logback.xml configuration by providing additionalField tags:

```
  <appender name="TEST" class="com.cwbase.logback.RedisAppender">
    <host>localhost</host>
    <key>logstash</key>
   ...
    <additionalField>
      <key>MyKey</key>
      <value>MyValue</value>
    </additionalField>
    <additionalField>
      <key>MySecondKey</key>
      <value>MyOtherValue</value>
    </additionalField>
  </appender
```

This will add two tags to the resulting JSON object:
```
{
  ...
  "MyKey": "MyValue",
  "MySecondKey": "MyOtherValue"
}
```